### PR TITLE
Activate github actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  Formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt
+      
+      - name: Check format
+        run: cargo fmt -- --check
+  
+  Linting:
+     runs-on: ubuntu-latest
+     steps:
+       - name: Checkout repository
+         uses: actions/checkout@v2
+
+       - name: Install stable toolchain
+         uses: actions-rs/toolchain@v1
+         with:
+           toolchain: stable
+           override: true
+           components: clippy
+
+       - name: Lint with clippy
+         uses: actions-rs/clippy-check@v1
+         with:
+           token: ${{ secrets.GITHUB_TOKEN }}
+
+  Testing:
+    needs: Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run cargo test
+        run: cargo test -- --test-threads=1
+

--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+  "test-agent": "my-api-key-123"
+}


### PR DESCRIPTION
This PR activates the GitHub Actions for antispam. The Actions include a format check, linting with clippy and running the (yet none existing) tests. It also adds an example `config.json` file which is needed for antispam to compile.